### PR TITLE
add Dockerfile and build.sh script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:20.04
+RUN apt update && apt install -y sdcc git make binutils
+COPY . /code
+WORKDIR /code
+RUN git submodule update
+WORKDIR /code/src
+RUN make

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -eu
+
+PROJECT=ch55xjtag
+
+docker build -t ${PROJECT} -f Dockerfile .
+docker run -v "${PWD}:/mnt" ${PROJECT} bash -c "cp -v /code/src/*.hex /mnt"


### PR DESCRIPTION
add Dockerfile and build.sh script, which build and copies usb_jtag.hex in the current directory.