### PR TITLE
main: Change memory space for ring buffer pointers

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -964,8 +964,8 @@ void Xtal_Enable(void) //使能外部时钟
 
 //Ring Buf
 
-volatile __idata uint8_t WritePtr = 0;
-volatile __idata uint8_t ReadPtr = 0;
+volatile __data uint8_t WritePtr = 0;
+volatile __data uint8_t ReadPtr = 0;
 
 #ifndef HARD_ESP_CTRL
 __code uint8_t ESP_Boot_Sequence[] =


### PR DESCRIPTION
- Move WritePtr and ReadPtr from __idata to __data memory
- Adjust for better memory utilization and compatibility

Closes: https://github.com/diodep/ch55x_jtag/issues/8